### PR TITLE
Always provide a usdPrice of the asset based on the quote price

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,6 @@ func main() {
 	web.InitialiseConfig()
 
 	log.Print("chainlink asset price adaptor")
-	log.Printf("Starting to serve on port %d", web.Config.Port)
+	log.Printf("starting to serve on port %d", web.Config.Port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", web.Config.Port), web.Api().MakeHandler()))
 }

--- a/web/api_test.go
+++ b/web/api_test.go
@@ -22,8 +22,14 @@ func TestBTCUSD(t *testing.T) {
 	assert.True(t, response.Params.Price != "0", "price returned from API is 0")
 	assert.True(t, response.Params.Volume != "0", "volume returned from API is 0")
 	assert.True(t, len(response.Params.Exchanges) > 1, "exchanges returned from API is less than 2")
-	assert.Equal(t, response.Params.Price, response.Params.USDPrice, "Price is meant to match USD price for USD quotes")
 	assert.Equal(t, response.Params.Id, "BTC-USD", "id of trading pair isn't correct")
+
+	assert.Equal(
+		t,
+		response.Params.Price,
+		response.Params.USDPrice.String,
+		"Price is meant to match USD price for USD quotes",
+	)
 }
 
 func TestETHEUR(t *testing.T) {
@@ -32,6 +38,7 @@ func TestETHEUR(t *testing.T) {
 	assert.True(t, response.Params.Price != "0", "price returned from API is 0")
 	assert.True(t, response.Params.Volume != "0", "volume returned from API is 0")
 	assert.True(t, len(response.Params.Exchanges) > 1, "exchanges returned from API is less than 2")
+	assert.Equal(t, response.Params.USDPrice.String, "", "usd price returned from API is 0")
 	assert.Equal(t, response.Params.Id, "ETH-EUR", "id of trading pair isn't correct")
 }
 
@@ -40,6 +47,7 @@ func TestLINKETH(t *testing.T) {
 
 	assert.True(t, response.Params.Price != "0", "price returned from API is 0")
 	assert.True(t, response.Params.Volume != "0", "volume returned from API is 0")
+	assert.True(t, response.Params.USDPrice.String != "0", "usd price is 0")
 	assert.True(t, len(response.Params.Exchanges) > 0, "exchanges returned from API was 0")
 	assert.Equal(t, response.Params.Id, "LINK-ETH", "id of trading pair isn't correct")
 }
@@ -49,6 +57,7 @@ func TestREQBTC(t *testing.T) {
 
 	assert.True(t, response.Params.Price != "0", "price returned from API is 0")
 	assert.True(t, response.Params.Volume != "0", "volume returned from API is 0")
+	assert.True(t, response.Params.USDPrice.String != "0", "usd price is 0")
 	assert.True(t, len(response.Params.Exchanges) > 0, "exchanges returned from API was 0")
 	assert.Equal(t, response.Params.Id, "REQ-BTC", "id of trading pair isn't correct")
 }
@@ -57,6 +66,7 @@ func TestUnknownPair(t *testing.T) {
 	response := getPairResponse("UNK", "UNK")
 	assert.Equal(t, response.Params.Price, "", "price returned from API is 0")
 	assert.Equal(t, response.Params.Volume, "", "volume returned from API is 0")
+	assert.Equal(t, response.Params.USDPrice.String, "", "usd price returned from API is 0")
 	assert.Equal(t, len(response.Params.Exchanges), 0, "exchanges returned from API was 0")
 	assert.Equal(t, response.Params.Id, "", "id of trading pair isn't correct")
 }

--- a/web/api_test.go
+++ b/web/api_test.go
@@ -1,18 +1,18 @@
 package web
 
 import (
-	"testing"
-	"net/http/httptest"
-	"net/http"
-	"log"
-	"io/ioutil"
-	"encoding/json"
-	"github.com/stretchr/testify/assert"
-	"fmt"
 	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
-func init(){
+func init() {
 	InitialiseConfig()
 }
 
@@ -22,6 +22,7 @@ func TestBTCUSD(t *testing.T) {
 	assert.True(t, response.Params.Price != "0", "price returned from API is 0")
 	assert.True(t, response.Params.Volume != "0", "volume returned from API is 0")
 	assert.True(t, len(response.Params.Exchanges) > 1, "exchanges returned from API is less than 2")
+	assert.Equal(t, response.Params.Price, response.Params.USDPrice, "Price is meant to match USD price for USD quotes")
 	assert.Equal(t, response.Params.Id, "BTC-USD", "id of trading pair isn't correct")
 }
 

--- a/web/price_controller.go
+++ b/web/price_controller.go
@@ -103,7 +103,7 @@ func StartPairsTicker() {
 	go func() {
 		for range ticker.C {
 			setExchangePairs()
-			log.Print("Trading pairs refreshed")
+			log.Print("trading pairs refreshed")
 		}
 	}()
 }


### PR DESCRIPTION
For #5 

Due to lack of volume on USD stable coin pairs, the adaptor will now return a `usdPrice` on every call based of the price of the quote asset. For example, if `LINK-BTC` is the pair, it will get the sats value as normal, but provide a `usdPrice` of LINK based on the aggregate price of BTC.